### PR TITLE
Add GBT_CAR_EXECTIME__DATE_ARG

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ Configuration
 
 The prompt (train) is assembled from several elements (cars). The look and
 behavior of whole train as well as each car can be influenced by a set of
-environment variables. Majority of the 
+environment variables. Majority of the
 
 
 ### Colors
@@ -555,6 +555,10 @@ Car that displays how long each shell command run.
 
   Background color of the car.
 
+- `GBT_CAR_EXECTIME__DATE_ARG='+%s.%N'`
+
+  Format argument for `date` command, used for calculation of execution time.
+
 - `GBT_CAR_EXECTIME_FG='black'`
 
   Foreground color of the car.
@@ -623,6 +627,8 @@ source /usr/share/gbt/sources/exec_time/bash
 source /usr/share/gbt/sources/exec_time/zsh
 ```
 
+On macOS the `date` command does not support `%N` format for milliseconds and
+you need to override the environment variable `GBT_CAR_EXECTIME__DATE_ARG='+%s`.
 
 #### `Git` car
 

--- a/sources/exec_time/bash
+++ b/sources/exec_time/bash
@@ -3,6 +3,12 @@ if [ -z "$GBT_CAR_EXECTIME__DATE" ]; then
     export GBT_CAR_EXECTIME__DATE='date'
 fi
 
+# Allow to override the date argument.
+# See https://github.com/jtyr/gbt/issues/14
+if [ -z "$GBT_CAR_EXECTIME__DATE_ARG" ]; then
+    export GBT_CAR_EXECTIME__DATE_ARG='+%s.%N'
+fi
+
 # Function executed before every command run by the shell
 function gbt_exectime_pre() {
     if [ -z $GBT_CAR_EXECTIME__TMP ]; then
@@ -11,7 +17,7 @@ function gbt_exectime_pre() {
 
     unset GBT_CAR_EXECTIME__TMP
 
-    export GBT_CAR_EXECTIME_SECS=$($GBT_CAR_EXECTIME__DATE '+%s.%N')
+    export GBT_CAR_EXECTIME_SECS=$($GBT_CAR_EXECTIME__DATE "$GBT_CAR_EXECTIME__DATE_ARG")
 }
 
 # Function executed after every command run by the shell
@@ -24,7 +30,7 @@ function gbt_exectime_post() {
     local BELL=${GBT_CAR_EXECTIME_BELL:-0}
 
     if (( $(echo "$SECS > 0" | bc) )) && (( $BELL > 0 )); then
-        local EXECS=$(echo "$(GBT_CAR_EXECTIME__DATE '+%s.%N') - $GBT_CAR_EXECTIME_SECS" | bc)
+        local EXECS=$(echo "$(GBT_CAR_EXECTIME__DATE "$GBT_CAR_EXECTIME__DATE_ARG") - $GBT_CAR_EXECTIME_SECS" | bc)
 
         if (( $(echo "$EXECS > $BELL" | bc) )); then
             echo -en '\a'


### PR DESCRIPTION
Add environment variable GBT_CAR_EXECTIME__DATE_ARG to control the format of the `date` command, used to calculate the execution time for ExecTime car.

Fixes #14 