### PR TITLE
Git: do not call `git status' if dirty/clean status is not needed

### DIFF
--- a/pkg/cars/git/main.go
+++ b/pkg/cars/git/main.go
@@ -112,11 +112,15 @@ func (c *Car) Init() {
 
     c.Display = utils.GetEnvBool("GBT_CAR_GIT_DISPLAY", isGitDir())
 
+    gitFormat := utils.GetEnv(
+	    "GBT_CAR_GIT_FORMAT",
+	    " {{ Icon }} {{ Head }} {{ Status }}{{ Ahead }}{{ Behind }} ")
+
     defaultStatusFormat := "{{ Clean }}"
     defaultAheadText := ""
     defaultBehindText := ""
 
-    if isDirty(c.Display) {
+    if strings.Contains(gitFormat, "{{ Status }}") && isDirty(c.Display) {
         defaultStatusFormat = "{{ Dirty }}"
     }
 
@@ -133,9 +137,7 @@ func (c *Car) Init() {
             Bg: utils.GetEnv("GBT_CAR_GIT_BG", defaultRootBg),
             Fg: utils.GetEnv("GBT_CAR_GIT_FG", defaultRootFg),
             Fm: utils.GetEnv("GBT_CAR_GIT_FM", defaultRootFm),
-            Text: utils.GetEnv(
-                "GBT_CAR_GIT_FORMAT",
-                " {{ Icon }} {{ Head }} {{ Status }}{{ Ahead }}{{ Behind }} "),
+            Text: gitFormat,
         },
         "Icon": {
             Bg: utils.GetEnv(


### PR DESCRIPTION
On a large repo `git status' can take a lot of time. For Linux kernel
repo it takes ~0.2s on my machine. It slows down gbt substantially.

Let's only call `git status' if user wants to see the status.