### PR TITLE
disable gbt_ssh when forcing pseudo-terminal

### DIFF
--- a/sources/gbts/README.md
+++ b/sources/gbts/README.md
@@ -38,6 +38,9 @@ The following variables must be configured before sourcing the `local.sh` file:
 # Don't use 'gbt_ssh' when connecting to 'myhost1' or 'myhost2'
 export GBT__SSH_IGNORE=(myhost1 myhost2)
 
+# Don't use gbt_ssh when forcing pseudo-terminal allocation
+export GBT__SSH_CATCH_PSEUDO_TERMINAL=true
+
 # List of cars to pack for the remote.
 # Should match or exceed the list of cars from the theme or the theme variables
 # (GBT__THEME_REMOTE_CARS and GBT__THEME_MYSQL_CARS).

--- a/sources/gbts/cmd/local/ssh.sh
+++ b/sources/gbts/cmd/local/ssh.sh
@@ -4,6 +4,8 @@ function gbt_ssh() {
 
     if [[ " ${GBT__SSH_IGNORE[*]} " == *" ${@: -1} "* ]]; then
         $SSH_BIN "$@"
+    elif [[ "$GBT__SSH_CATCH_PSEUDO_TERMINAL" == true ]] && [[ " ${@} " == *" -t "* ]]; then
+        $SSH_BIN "$@";
     else
         local RDN=$RANDOM
         local GBT__CONF="/tmp/.gbt.$RDN"


### PR DESCRIPTION
gbt_ssh fails to force pseudo-terminal and attach to an already running screen-based program on a remote server, probably because the gbt_ssh is using -t.

I've added a `$GBT__SSH_CATCH_PSEUDO_TERMINAL` and if set to `true` it will not use gbt_ssh if user invoked ssh with -t as option 