### PR TITLE
Don't use gbts_ssh when executing remote commands

### DIFF
--- a/sources/gbts/cmd/_common.sh
+++ b/sources/gbts/cmd/_common.sh
@@ -78,4 +78,33 @@ function gbt__finish() {
 }
 
 
+function gbt__is_ssh_command() {
+    # Parse through ssh command options and determine
+    # if there is a remote command to be executed
+    local SSH_DUAL_OPTIONS="BbcDEeFIiJLlmOopQRSWw"
+    while (( "$#" )); do
+        #check if it's an option and start with dash
+        if [[ "${1:0:1}" == "-" ]]; then
+            #check $1 is a option with argument, then do an extra shift
+            if [[ "$SSH_DUAL_OPTIONS" =~ "${1:1}" ]]; then
+                shift
+            fi
+            shift
+        else
+            #shift over ssh destination
+            shift
+            if [[ -z "$@" ]];then
+                # no command specified to be executed on remote host
+                return 1
+            else
+                # command specified to be exexuted
+                return 0
+            fi
+            break
+        fi
+
+    done
+}
+
+
 trap gbt__finish EXIT

--- a/sources/gbts/cmd/_common.sh
+++ b/sources/gbts/cmd/_common.sh
@@ -42,6 +42,19 @@ function gbt__is_ssh_command() {
 }
 
 
+function gbt__is_vagrant_ssh_command() {
+    # Parse through vagrant ssh to see if -c or --command is specified
+    while (( "$#" )); do
+        if [[ "$1" == "-c" ]] || [[ "$1" == "--command" ]]; then
+            return 0
+            break
+        fi
+        shift
+    done
+    return 1
+}
+
+
 function gbt__which() {
     local PROG=$1
 

--- a/sources/gbts/cmd/_common.sh
+++ b/sources/gbts/cmd/_common.sh
@@ -11,15 +11,13 @@
 
 
 function gbt__is_ssh_command() {
-    # Parse through ssh command options and determine
-    # If there is a remote command to be executed
-    local SSH_DUAL_OPTIONS="BbcDEeFIiJLlmOopQRSWw"
-
-    while [[ $# -gt 0 ]]; do
+    # Parse through ssh command options and determine if there is a remote
+    # command to be executed
+    while [ $# -gt 0 ]; do
         # Check if it's an option and start with dash
-        if [[ "${1:0:1}" == "-" ]]; then
+        if [[ ${1:0:1} == '-' ]]; then
             # Check $1 is a option with argument, then do an extra shift
-            if [[ "$SSH_DUAL_OPTIONS" =~ "${1:1}" ]]; then
+            if [[ 'BbcDEeFIiJLlmOopQRSWw' =~ ${1:1} ]]; then
                 shift
             fi
 
@@ -44,13 +42,14 @@ function gbt__is_ssh_command() {
 
 function gbt__is_vagrant_ssh_command() {
     # Parse through vagrant ssh to see if -c or --command is specified
-    while (( "$#" )); do
-        if [[ "$1" == "-c" ]] || [[ "$1" == "--command" ]]; then
+    while [ $# -gt 0 ]; do
+        if [[ $1 == '-c' ]] || [[ $1 == '--command' ]]; then
             return 0
-            break
         fi
+
         shift
     done
+
     return 1
 }
 

--- a/sources/gbts/cmd/_common.sh
+++ b/sources/gbts/cmd/_common.sh
@@ -80,29 +80,32 @@ function gbt__finish() {
 
 function gbt__is_ssh_command() {
     # Parse through ssh command options and determine
-    # if there is a remote command to be executed
+    # If there is a remote command to be executed
     local SSH_DUAL_OPTIONS="BbcDEeFIiJLlmOopQRSWw"
-    while (( "$#" )); do
-        #check if it's an option and start with dash
+
+    while [[ $# -gt 0 ]]; do
+        # Check if it's an option and start with dash
         if [[ "${1:0:1}" == "-" ]]; then
-            #check $1 is a option with argument, then do an extra shift
+            # Check $1 is a option with argument, then do an extra shift
             if [[ "$SSH_DUAL_OPTIONS" =~ "${1:1}" ]]; then
                 shift
             fi
+
             shift
         else
-            #shift over ssh destination
+            # Shift over ssh destination
             shift
+
             if [[ -z "$@" ]];then
-                # no command specified to be executed on remote host
+                # No command specified to be executed on remote host
                 return 1
             else
-                # command specified to be exexuted
+                # Command specified to be exexuted
                 return 0
             fi
+
             break
         fi
-
     done
 }
 

--- a/sources/gbts/cmd/_common.sh
+++ b/sources/gbts/cmd/_common.sh
@@ -10,6 +10,38 @@
 [ -z "$GBT__CONF_BASH_MODE" ] && GBT__CONF_BASH_MODE='0755'
 
 
+function gbt__is_ssh_command() {
+    # Parse through ssh command options and determine
+    # If there is a remote command to be executed
+    local SSH_DUAL_OPTIONS="BbcDEeFIiJLlmOopQRSWw"
+
+    while [[ $# -gt 0 ]]; do
+        # Check if it's an option and start with dash
+        if [[ "${1:0:1}" == "-" ]]; then
+            # Check $1 is a option with argument, then do an extra shift
+            if [[ "$SSH_DUAL_OPTIONS" =~ "${1:1}" ]]; then
+                shift
+            fi
+
+            shift
+        else
+            # Shift over ssh destination
+            shift
+
+            if [[ -z "$@" ]]; then
+                # No command specified to be executed on remote host
+                return 1
+            else
+                # Command specified to be exexuted
+                return 0
+            fi
+
+            break
+        fi
+    done
+}
+
+
 function gbt__which() {
     local PROG=$1
 
@@ -75,38 +107,6 @@ function gbt__finish() {
         # Cleanup at the end of the 'ssh' or 'vagrant' session
         rm -f $GBT__CONF $GBT__CONF.bash
     fi
-}
-
-
-function gbt__is_ssh_command() {
-    # Parse through ssh command options and determine
-    # If there is a remote command to be executed
-    local SSH_DUAL_OPTIONS="BbcDEeFIiJLlmOopQRSWw"
-
-    while [[ $# -gt 0 ]]; do
-        # Check if it's an option and start with dash
-        if [[ "${1:0:1}" == "-" ]]; then
-            # Check $1 is a option with argument, then do an extra shift
-            if [[ "$SSH_DUAL_OPTIONS" =~ "${1:1}" ]]; then
-                shift
-            fi
-
-            shift
-        else
-            # Shift over ssh destination
-            shift
-
-            if [[ -z "$@" ]];then
-                # No command specified to be executed on remote host
-                return 1
-            else
-                # Command specified to be exexuted
-                return 0
-            fi
-
-            break
-        fi
-    done
 }
 
 

--- a/sources/gbts/cmd/_common.sh
+++ b/sources/gbts/cmd/_common.sh
@@ -10,50 +10,6 @@
 [ -z "$GBT__CONF_BASH_MODE" ] && GBT__CONF_BASH_MODE='0755'
 
 
-function gbt__is_ssh_command() {
-    # Parse through ssh command options and determine if there is a remote
-    # command to be executed
-    while [ $# -gt 0 ]; do
-        # Check if it's an option and start with dash
-        if [[ ${1:0:1} == '-' ]]; then
-            # Check $1 is a option with argument, then do an extra shift
-            if [[ 'BbcDEeFIiJLlmOopQRSWw' =~ ${1:1} ]]; then
-                shift
-            fi
-
-            shift
-        else
-            # Shift over ssh destination
-            shift
-
-            if [[ -z "$@" ]]; then
-                # No command specified to be executed on remote host
-                return 1
-            else
-                # Command specified to be exexuted
-                return 0
-            fi
-
-            break
-        fi
-    done
-}
-
-
-function gbt__is_vagrant_ssh_command() {
-    # Parse through vagrant ssh to see if -c or --command is specified
-    while [ $# -gt 0 ]; do
-        if [[ $1 == '-c' ]] || [[ $1 == '--command' ]]; then
-            return 0
-        fi
-
-        shift
-    done
-
-    return 1
-}
-
-
 function gbt__which() {
     local PROG=$1
 

--- a/sources/gbts/cmd/_common_ssh.sh
+++ b/sources/gbts/cmd/_common_ssh.sh
@@ -1,0 +1,28 @@
+function gbt__is_ssh_command() {
+    # Parse through ssh command options and determine if there is a remote
+    # command to be executed
+    while [ $# -gt 0 ]; do
+        # Check if it's an option and start with dash
+        if [[ ${1:0:1} == '-' ]]; then
+            # Check $1 is a option with argument, then do an extra shift
+            if [[ 'BbcDEeFIiJLlmOopQRSWw' =~ ${1:1} ]]; then
+                shift
+            fi
+
+            shift
+        else
+            # Shift over ssh destination
+            shift
+
+            if [[ -z "$@" ]]; then
+                # No command specified to be executed on remote host
+                return 1
+            else
+                # Command specified to be exexuted
+                return 0
+            fi
+
+            break
+        fi
+    done
+}

--- a/sources/gbts/cmd/_common_vagrant.sh
+++ b/sources/gbts/cmd/_common_vagrant.sh
@@ -1,0 +1,12 @@
+function gbt__is_vagrant_ssh_command() {
+    # Parse through vagrant ssh to see if -c or --command is specified
+    while [ $# -gt 0 ]; do
+        if [[ $1 == '-c' ]] || [[ $1 == '--command' ]]; then
+            return 0
+        fi
+
+        shift
+    done
+
+    return 1
+}

--- a/sources/gbts/cmd/local.sh
+++ b/sources/gbts/cmd/local.sh
@@ -12,6 +12,7 @@ if [[ ${GBT__PLUGINS_LOCAL__HASH[@]} == *' screen '* ]]; then
 fi
 if [[ ${GBT__PLUGINS_LOCAL__HASH[@]} == *' ssh '* ]]; then
     source $GBT__HOME/sources/gbts/cmd/local/ssh.sh
+    source $GBT__HOME/sources/gbts/cmd/_common_ssh.sh
 fi
 if [[ ${GBT__PLUGINS_LOCAL__HASH[@]} == *' su '* ]]; then
     source $GBT__HOME/sources/gbts/cmd/local/su.sh
@@ -21,4 +22,5 @@ if [[ ${GBT__PLUGINS_LOCAL__HASH[@]} == *' sudo '* ]]; then
 fi
 if [[ ${GBT__PLUGINS_LOCAL__HASH[@]} == *' vagrant '* ]]; then
     source $GBT__HOME/sources/gbts/cmd/local/vagrant.sh
+    source $GBT__HOME/sources/gbts/cmd/_common_vagrant.sh
 fi

--- a/sources/gbts/cmd/local/_common.sh
+++ b/sources/gbts/cmd/local/_common.sh
@@ -49,6 +49,16 @@ function gbt__get_sources() {
         echo "export GBT__CONF='$GBT__CONF'"
         cat $GBT__HOME/sources/gbts/{cmd{,/remote},car}/_common.sh
 
+        # Include SSH common function if car is present
+        if [[ ${GBT__PLUGINS_REMOTE__HASH[@]} == *' ssh '* ]]; then
+            cat $GBT__HOME/sources/gbts/cmd/_common_ssh.sh
+        fi
+
+        # Include Vagrant common function if car is present
+        if [[ ${GBT__PLUGINS_REMOTE__HASH[@]} == *' vagrant '* ]]; then
+            cat $GBT__HOME/sources/gbts/cmd/_common_vagrant.sh
+        fi
+
         # Preserver modes
         [ "$GBT__CONF_MODE" != '0600' ] && echo "export GBT__CONF_MODE='$GBT__CONF_MODE'"
         [ "$GBT__CONF_BASH_MODE" != '0755' ] && echo "export GBT__CONF_BASH_MODE='$GBT__CONF_BASH_MODE'"

--- a/sources/gbts/cmd/local/ssh.sh
+++ b/sources/gbts/cmd/local/ssh.sh
@@ -1,37 +1,8 @@
-function remote_ssh_command {
-    # Parse through ssh command options and determine
-    # if there is a remote command to be executed
-    local SSH_DUAL_OPTIONS="BbcDEeFIiJLlmOopQRSWw"
-    while (( "$#" )); do
-        #check if it's an option and start with dash
-        if [[ "${1:0:1}" == "-" ]]; then
-            #check $1 is a option with argument, then do an extra shift
-            if [[ "$SSH_DUAL_OPTIONS" =~ "${1:1}" ]]; then
-                shift
-            fi
-            shift
-        else
-            #shift over ssh destination
-            shift
-            if [[ -z "$@" ]];then
-                # no command specified to be executed on remote host
-                return 1
-            else
-                # command specified to be exexuted
-                return 0
-            fi
-            break
-        fi
-    done
-}
-
 function gbt_ssh() {
     local SSH_BIN=$(gbt__which ssh)
     [ -z "$SSH_BIN" ] && return 1
 
-    if [[ " ${GBT__SSH_IGNORE[*]} " == *" ${@: -1} "* ]]; then
-        $SSH_BIN "$@"
-    elif remote_ssh_command "$@"; then
+	if [[ " ${GBT__SSH_IGNORE[*]} " == *" ${@: -1} "* ]] || (gbt__is_ssh_command "$@"); then
         $SSH_BIN "$@"
     else
         local RND=$RANDOM

--- a/sources/gbts/cmd/local/ssh.sh
+++ b/sources/gbts/cmd/local/ssh.sh
@@ -2,7 +2,7 @@ function gbt_ssh() {
     local SSH_BIN=$(gbt__which ssh)
     [ -z "$SSH_BIN" ] && return 1
 
-	if [[ " ${GBT__SSH_IGNORE[*]} " == *" ${@: -1} "* ]] || (gbt__is_ssh_command "$@"); then
+    if [[ " ${GBT__SSH_IGNORE[*]} " == *" ${@: -1} "* ]] || ( gbt__is_ssh_command "$@" ); then
         $SSH_BIN "$@"
     else
         local RND=$RANDOM

--- a/sources/gbts/cmd/local/ssh.sh
+++ b/sources/gbts/cmd/local/ssh.sh
@@ -1,8 +1,37 @@
+function remote_ssh_command {
+    # Parse through ssh command options and determine
+    # if there is a remote command to be executed
+    local SSH_DUAL_OPTIONS="BbcDEeFIiJLlmOopQRSWw"
+    while (( "$#" )); do
+        #check if it's an option and start with dash
+        if [[ "${1:0:1}" == "-" ]]; then
+            #check $1 is a option with argument, then do an extra shift
+            if [[ "$SSH_DUAL_OPTIONS" =~ "${1:1}" ]]; then
+                shift
+            fi
+            shift
+        else
+            #shift over ssh destination
+            shift
+            if [[ -z "$@" ]];then
+                # no command specified to be executed on remote host
+                return 1
+            else
+                # command specified to be exexuted
+                return 0
+            fi
+            break
+        fi
+    done
+}
+
 function gbt_ssh() {
     local SSH_BIN=$(gbt__which ssh)
     [ -z "$SSH_BIN" ] && return 1
 
     if [[ " ${GBT__SSH_IGNORE[*]} " == *" ${@: -1} "* ]]; then
+        $SSH_BIN "$@"
+    elif remote_ssh_command "$@"; then
         $SSH_BIN "$@"
     else
         local RND=$RANDOM

--- a/sources/gbts/cmd/local/vagrant.sh
+++ b/sources/gbts/cmd/local/vagrant.sh
@@ -2,9 +2,7 @@ function gbt_vagrant() {
     local VAGRANT_BIN=$(gbt__which vagrant)
     [ -z "$VAGRANT_BIN" ] && return 1
 
-    if [ "$1" != 'ssh' ]; then
-        $VAGRANT_BIN "$@"
-    elif ( gbt__is_vagrant_ssh_command "$@" ); then
+    if [ "$1" != 'ssh' ] || ( gbt__is_vagrant_ssh_command "$@" ); then
         $VAGRANT_BIN "$@"
     else
         shift

--- a/sources/gbts/cmd/local/vagrant.sh
+++ b/sources/gbts/cmd/local/vagrant.sh
@@ -4,6 +4,8 @@ function gbt_vagrant() {
 
     if [ "$1" != 'ssh' ]; then
         $VAGRANT_BIN "$@"
+    elif ( gbt__is_vagrant_ssh_command "$@" ); then
+        $VAGRANT_BIN "$@"
     else
         shift
 

--- a/sources/gbts/cmd/local/vagrant.sh
+++ b/sources/gbts/cmd/local/vagrant.sh
@@ -2,9 +2,7 @@ function gbt_vagrant() {
     local VAGRANT_BIN=$(gbt__which vagrant)
     [ -z "$VAGRANT_BIN" ] && return 1
 
-    if [ "$1" != 'ssh' ] || ( gbt__is_vagrant_ssh_command "$@" ); then
-        $VAGRANT_BIN "$@"
-    else
+    if [[ $1 == 'ssh' ]] && ( ! gbt__is_vagrant_ssh_command "$@" ); then
         shift
 
         local RND=$RANDOM
@@ -21,5 +19,7 @@ else
   gbt__$RND > $GBT__CONF;
 fi;
 exec -a gbt.bash bash --rcfile \$GBT__CONF" "$@"
+    else
+        $VAGRANT_BIN "$@"
     fi
 }

--- a/sources/gbts/cmd/remote/ssh.sh
+++ b/sources/gbts/cmd/remote/ssh.sh
@@ -2,10 +2,13 @@ function gbt_ssh() {
     local SSH_BIN=$(gbt__which ssh)
     [ -z "$SSH_BIN" ] && return 1
 
-    gbt__check_md5
-
-    $SSH_BIN -t "$@" "cat /etc/motd 2>/dev/null;
+    if gbt__is_ssh_command "$@"; then
+        $SSH_BIN "$@"
+    else
+        gbt__check_md5
+        $SSH_BIN -t "$@" "cat /etc/motd 2>/dev/null;
 echo \"$(cat $GBT__CONF | eval "$GBT__SOURCE_COMPRESS" | $GBT__SOURCE_BASE64 | tr -d '\r\n')\" | $GBT__SOURCE_BASE64 $GBT__SOURCE_BASE64_DEC | $GBT__SOURCE_DECOMPRESS > $GBT__CONF &&
 chmod $GBT__CONF_MODE $GBT__CONF &&
 exec -a gbt.bash bash --rcfile $GBT__CONF"
+    fi
 }

--- a/sources/gbts/cmd/remote/ssh.sh
+++ b/sources/gbts/cmd/remote/ssh.sh
@@ -6,6 +6,7 @@ function gbt_ssh() {
         $SSH_BIN "$@"
     else
         gbt__check_md5
+
         $SSH_BIN -t "$@" "cat /etc/motd 2>/dev/null;
 echo \"$(cat $GBT__CONF | eval "$GBT__SOURCE_COMPRESS" | $GBT__SOURCE_BASE64 | tr -d '\r\n')\" | $GBT__SOURCE_BASE64 $GBT__SOURCE_BASE64_DEC | $GBT__SOURCE_DECOMPRESS > $GBT__CONF &&
 chmod $GBT__CONF_MODE $GBT__CONF &&

--- a/sources/gbts/cmd/remote/ssh.sh
+++ b/sources/gbts/cmd/remote/ssh.sh
@@ -2,7 +2,7 @@ function gbt_ssh() {
     local SSH_BIN=$(gbt__which ssh)
     [ -z "$SSH_BIN" ] && return 1
 
-    if gbt__is_ssh_command "$@"; then
+    if ( gbt__is_ssh_command "$@" ); then
         $SSH_BIN "$@"
     else
         gbt__check_md5

--- a/sources/gbts/cmd/remote/vagrant.sh
+++ b/sources/gbts/cmd/remote/vagrant.sh
@@ -4,14 +4,14 @@ function gbt_vagrant() {
 
     gbt__check_md5
 
-    if [ "$1" != 'ssh' ] || ( gbt__is_vagrant_ssh_command "$@" ); then
-        $VAGRANT_BIN "$@"
-    else
+    if [[ $1 == 'ssh' ]] && ( ! gbt__is_vagrant_ssh_command "$@" ); then
         shift
 
         $VAGRANT_BIN ssh --command "cat /etc/motd 2>/dev/null;
 echo \"$(cat $GBT__CONF | eval "$GBT__SOURCE_COMPRESS" | $GBT__SOURCE_BASE64 | tr -d '\r\n')\" | $GBT__SOURCE_BASE64 $GBT__SOURCE_BASE64_DEC | $GBT__SOURCE_DECOMPRESS > $GBT__CONF &&
 chmod $GBT__CONF_MODE $GBT__CONF &&
 exec -a gbt.bash bash --rcfile $GBT__CONF" "$@"
+    else
+        $VAGRANT_BIN "$@"
     fi
 }

--- a/sources/gbts/cmd/remote/vagrant.sh
+++ b/sources/gbts/cmd/remote/vagrant.sh
@@ -6,6 +6,8 @@ function gbt_vagrant() {
 
     if [ "$1" != 'ssh' ]; then
         $VAGRANT_BIN "$@"
+    elif ( gbt__is_vagrant_ssh_command "$@" ); then
+        $VAGRANT_BIN "$@"
     else
         shift
 

--- a/sources/gbts/cmd/remote/vagrant.sh
+++ b/sources/gbts/cmd/remote/vagrant.sh
@@ -4,9 +4,7 @@ function gbt_vagrant() {
 
     gbt__check_md5
 
-    if [ "$1" != 'ssh' ]; then
-        $VAGRANT_BIN "$@"
-    elif ( gbt__is_vagrant_ssh_command "$@" ); then
+    if [ "$1" != 'ssh' ] || ( gbt__is_vagrant_ssh_command "$@" ); then
         $VAGRANT_BIN "$@"
     else
         shift


### PR DESCRIPTION
when executing a remote command with ssh the ssh client should just print the result and exit to the prompt on the local machine
```
  jonas@exsilio  ~   /usr/bin/ssh nas1 uptime
 14:43:35  up 21 days 19:51,  0 users,  load average: 0,14, 0,04, 0,02
  jonas@exsilio  ~  
```

when using gbt_ssh wrapper that doesn't work, it just dropped to a prompt at the remote host
```
   jonas@exsilio  ~   gbt_ssh nas1 uptime
   jonas@nas1  ~  $ 
```

If I try to do a remote `ls -l` on a remote host I would expect the result be displayed and the ssh session to be closed and then the prompt is returned to my local machine
```
   jonas@exsilio  ~   /usr/bin/ssh nas1 ls -l /tmp
total 17168
-rw-r--r-- 1 jonas users   120272 14 jan 08.51 error.jpg
-rw-r--r-- 1 root  root      5581 30 dec 11.07 grains.txt
drwxr-xr-x 1 jonas users       52 13 maj  2018 pillar
<cut>
..
..
</cut>
   jonas@exsilio  ~  
```

but with gbt_ssh wrapper the result is:
```
 gbt_ssh nas1 ls -l /tmp
-rw-r--r-- 1 root root   21 16 maj  2018 /etc/motd

/tmp:
total 17168
-rw-r--r-- 1 jonas users   120272 14 jan 08.51 error.jpg
-rw-r--r-- 1 root  root      5581 30 dec 11.07 grains.txt
drwxr-xr-x 1 jonas users       52 13 maj  2018 pillar
<cut>
..
..
</cut>
   jonas@nas1  ~  $ 
```
It shows an extra listing of the /etc/motd and the ssh session is still open to the remote machine.

This PR will parse the ssh options and arguments passed to gbt_ssh funtion and if a remote command is specified it will execute the options and arguments with plain `$SSH_BIN`, just like if it was in the `$GBT__SSH_INGORE` list

It wouldn't be neccesary to create the PS1 on remote host in those cases. 
This would also catch the foring pseudo terminal cases.

