### PR TITLE
Add os icon for opensuse leap, tumbleweed and sles

### DIFF
--- a/pkg/cars/os/main.go
+++ b/pkg/cars/os/main.go
@@ -26,38 +26,40 @@ var symbols = map[string]iconColor {
     // Unicode codes and font names are taken from https://nerdfonts.com
     // If adding a new symbol, always choose the smaller picture if multiple
     // symbols are available.
-    "amzn":       { icon: "\uf52c", color: "208", }, // nf-mdi-amazon
-    "android":    { icon: "\uf17b", color: "113", }, // nf-fa-android
-    "arch":       { icon: "\uf303", color: "25",  }, // nf-linux-archlinux
-    "archarm":    { icon: "\uf303", color: "125", }, // nf-linux-archlinux
-    "alpine":     { icon: "\uf300", color: "24",  }, // nf-linux-alpine
-    "aosc":       { icon: "\uf301", color: "172", }, // nf-linux-aosc
-    "centos":     { icon: "\uf304", color: "27",  }, // nf-linux-centos
-    "cloud":      { icon: "\uf65e", color: "39",  }, // nf-mdi-cloud
-    "coreos":     { icon: "\uf305", color: "32",  }, // nf-linux-coreos
-    "darwin":     { icon: "\uf534", color: "15",  }, // nf-mdi-apple
-    "debian":     { icon: "\ue77d", color: "88",  }, // nf-dev-debian
-    "devuan":     { icon: "\uf307", color: "16",  }, // nf-linux-devuan
-    "docker":     { icon: "\ue7b0", color: "26",  }, // nf-dev-docker
-    "elementary": { icon: "\uf309", color: "33",  }, // nf-linux-elementary
-    "fedora":     { icon: "\uf30a", color: "32",  }, // nf-linux-fedora
-    "freebsd":    { icon: "\uf30c", color: "1",   }, // nf-linux-freebsd
-    "gentoo":     { icon: "\uf30d", color: "62",  }, // nf-linux-gentoo
-    "linux":      { icon: "\uf17c", color: "15",  }, // nf-fa-linux
-    "linuxmint":  { icon: "\uf30e", color: "47",  }, // nf-linux-linuxmint
-    "mageia":     { icon: "\uf310", color: "24",  }, // nf-linux-mageia
-    "mandriva":   { icon: "\uf311", color: "208", }, // nf-linux-mandriva
-    "manjaro":    { icon: "\uf312", color: "34",  }, // nf-linux-manjaro
-    "mysql":      { icon: "\ue704", color: "30",  }, // nf-dev-mysql
-    "nixos":      { icon: "\uf313", color: "88",  }, // nf-linux-nixos
-    "opensuse":   { icon: "\uf314", color: "113", }, // nf-linux-opensuse
-    "raspbian":   { icon: "\uf315", color: "125", }, // nf-linux-raspberry_pi
-    "redhat":     { icon: "\ue7bb", color: "1",   }, // nf-dev-redhat
-    "sabayon":    { icon: "\uf317", color: "255", }, // nf-linux-sabayon
-    "slackware":  { icon: "\uf318", color: "63",  }, // nf-linux-slackware
-    "sles":       { icon: "\uf314", color: "113", }, // nf-linux-opensuse
-    "ubuntu":     { icon: "\uf31b", color: "166", }, // nf-linux-ubuntu
-    "windows":    { icon: "\ue62a", color: "6",   }, // nf-custom-windows
+    "amzn":                { icon: "\uf52c", color: "208", }, // nf-mdi-amazon
+    "android":             { icon: "\uf17b", color: "113", }, // nf-fa-android
+    "arch":                { icon: "\uf303", color: "25",  }, // nf-linux-archlinux
+    "archarm":             { icon: "\uf303", color: "125", }, // nf-linux-archlinux
+    "alpine":              { icon: "\uf300", color: "24",  }, // nf-linux-alpine
+    "aosc":                { icon: "\uf301", color: "172", }, // nf-linux-aosc
+    "centos":              { icon: "\uf304", color: "27",  }, // nf-linux-centos
+    "cloud":               { icon: "\uf65e", color: "39",  }, // nf-mdi-cloud
+    "coreos":              { icon: "\uf305", color: "32",  }, // nf-linux-coreos
+    "darwin":              { icon: "\uf534", color: "15",  }, // nf-mdi-apple
+    "debian":              { icon: "\ue77d", color: "88",  }, // nf-dev-debian
+    "devuan":              { icon: "\uf307", color: "16",  }, // nf-linux-devuan
+    "docker":              { icon: "\ue7b0", color: "26",  }, // nf-dev-docker
+    "elementary":          { icon: "\uf309", color: "33",  }, // nf-linux-elementary
+    "fedora":              { icon: "\uf30a", color: "32",  }, // nf-linux-fedora
+    "freebsd":             { icon: "\uf30c", color: "1",   }, // nf-linux-freebsd
+    "gentoo":              { icon: "\uf30d", color: "62",  }, // nf-linux-gentoo
+    "linux":               { icon: "\uf17c", color: "15",  }, // nf-fa-linux
+    "linuxmint":           { icon: "\uf30e", color: "47",  }, // nf-linux-linuxmint
+    "mageia":              { icon: "\uf310", color: "24",  }, // nf-linux-mageia
+    "mandriva":            { icon: "\uf311", color: "208", }, // nf-linux-mandriva
+    "manjaro":             { icon: "\uf312", color: "34",  }, // nf-linux-manjaro
+    "mysql":               { icon: "\ue704", color: "30",  }, // nf-dev-mysql
+    "nixos":               { icon: "\uf313", color: "88",  }, // nf-linux-nixos
+    "opensuse":            { icon: "\uf314", color: "113", }, // nf-linux-opensuse
+    "opensuse-leap":       { icon: "\uf314", color: "113", }, // nf-linux-opensuse
+    "opensuse-tumbleweed": { icon: "\uf314", color: "113", }, // nf-linux-opensuse
+    "raspbian":            { icon: "\uf315", color: "125", }, // nf-linux-raspberry_pi
+    "redhat":              { icon: "\ue7bb", color: "1",   }, // nf-dev-redhat
+    "sabayon":             { icon: "\uf317", color: "255", }, // nf-linux-sabayon
+    "slackware":           { icon: "\uf318", color: "63",  }, // nf-linux-slackware
+    "sles":                { icon: "\uf314", color: "113", }, // nf-linux-opensuse
+    "ubuntu":              { icon: "\uf31b", color: "166", }, // nf-linux-ubuntu
+    "windows":             { icon: "\ue62a", color: "6",   }, // nf-custom-windows
 }
 
 // Holds the OS name.
@@ -92,10 +94,6 @@ func getOsName() string {
             if len(line) > 3 && line[:3] == "ID=" {
                 osName = strings.Replace(
                     strings.Replace(line[3:], "\"", "", -1), "'", "", -1)
-            }
-
-            if len(osName) > 8 && osName[:8] == "opensuse" {
-                osName = osName[:8]
             }
         }
     }

--- a/pkg/cars/os/main.go
+++ b/pkg/cars/os/main.go
@@ -55,6 +55,7 @@ var symbols = map[string]iconColor {
     "redhat":     { icon: "\ue7bb", color: "1",   }, // nf-dev-redhat
     "sabayon":    { icon: "\uf317", color: "255", }, // nf-linux-sabayon
     "slackware":  { icon: "\uf318", color: "63",  }, // nf-linux-slackware
+    "sles":       { icon: "\uf314", color: "113", }, // nf-linux-opensuse
     "ubuntu":     { icon: "\uf31b", color: "166", }, // nf-linux-ubuntu
     "windows":    { icon: "\ue62a", color: "6",   }, // nf-custom-windows
 }
@@ -91,6 +92,10 @@ func getOsName() string {
             if len(line) > 3 && line[:3] == "ID=" {
                 osName = strings.Replace(
                     strings.Replace(line[3:], "\"", "", -1), "'", "", -1)
+            }
+
+            if len(osName) > 8 && osName[:8] == "opensuse" {
+                osName = osName[:8]
             }
         }
     }

--- a/pkg/cars/os/main_test.go
+++ b/pkg/cars/os/main_test.go
@@ -26,16 +26,6 @@ func TestInitDefault(t *testing.T) {
             osRelease: "/etc/os-release",
             expectedOutput: "?",
         },
-        {
-            name: "opensuse-leap",
-            osRelease: "/etc/os-release",
-            expectedOutput: "\uf314",
-        },
-        {
-            name: "opensuse-tumbleweed",
-            osRelease: "/etc/os-release",
-            expectedOutput: "\uf314",
-        },
     }
 
     for i, test := range tests {

--- a/pkg/cars/os/main_test.go
+++ b/pkg/cars/os/main_test.go
@@ -26,6 +26,16 @@ func TestInitDefault(t *testing.T) {
             osRelease: "/etc/os-release",
             expectedOutput: "?",
         },
+        {
+            name: "opensuse-leap",
+            osRelease: "/etc/os-release",
+            expectedOutput: "\uf314",
+        },
+        {
+            name: "opensuse-tumbleweed",
+            osRelease: "/etc/os-release",
+            expectedOutput: "\uf314",
+        },
     }
 
     for i, test := range tests {

--- a/sources/gbts/car/os.sh
+++ b/sources/gbts/car/os.sh
@@ -30,6 +30,7 @@ GBT__OS_SYMBOLS=(
     [rhel]='\xee\x9e\xbb'           [rhel_color]=1
     [sabayon]='\xef\x8c\x97'        [sabayon_color]=255
     [slackware]='\xef\x8c\x98'      [slackware_color]=63
+    [sles]='\xef\x8c\x94'           [sles_color]=113
     [ubuntu]='\xef\x8c\x9b'         [ubuntu_color]=166
     [windows]='\xee\x98\xaa'        [windows_color]=6
 )
@@ -48,6 +49,10 @@ function GbtCarOs() {
             os='darwin'
         elif [ "$os" = 'Linux' ] && [ -e /etc/os-release ]; then
             os=$(source /etc/os-release; echo "$ID")
+
+            case $os in opensuse-*)
+                os="opensuse"
+            esac
 
             if [ ! ${GBT__OS_SYMBOLS[$os]+1} ]; then
                 os='linux'

--- a/sources/gbts/car/os.sh
+++ b/sources/gbts/car/os.sh
@@ -1,38 +1,40 @@
 declare -A GBT__OS_SYMBOLS
 GBT__OS_SYMBOLS=(
-    [amzn]='\xef\x94\xac'           [amzn_color]=208
-    [android]='\xef\x85\xbb'        [android_color]=113
-    [arch]='\xef\x8c\x83'           [arch_color]=25
-    [archarm]='\xef\x8c\x83'        [archarm_color]=125
-    [alpine]='\xef\x8c\x80'         [alpine_color]=24
-    [aosc]='\xef\x8c\x81'           [aosc_color]=172
-    [centos]='\xef\x8c\x84'         [centos_color]=27
-    [cloud]='\xef\x99\x9e'          [cloud_color]=39
-    [coreos]='\xef\x8c\x85'         [coreos_color]=32
-    [darwin]='\xef\x94\xb4'         [darwin_color]=15
-    [debian]='\xee\x9d\xbd'         [debian_color]=88
-    [devuan]='\xef\x8c\x87'         [devuan_color]=16
-    [docker]='\xee\x9e\xb0'         [docker_color]=26
-    [elementary]='\xef\x8c\x89'     [elementary_color]=33
-    [fedora]='\xef\x8c\x8a'         [fedora_color]=32
-    [freebsd]='\xef\x8c\x8c'        [freebsd_color]=1
-    [gentoo]='\xef\x8c\x8d'         [gentoo_color]=62
-    [linux]='\xef\x85\xbc'          [linux_color]=15
-    [linuxmint]='\xef\x8c\x8e'      [linuxmint_color]=47
-    [mageia]='\xef\x8c\x90'         [mageia_color]=24
-    [mandriva]='\xef\x8c\x91'       [mandriva_color]=208
-    [manjaro]='\xef\x8c\x92'        [manjaro_color]=34
-    [mysql]='\xee\x9c\x84'          [mysql_color]=30
-    [nixos]='\xef\x8c\x93'          [nixos_color]=88
-    [opensuse]='\xef\x8c\x94'       [opensuse_color]=113
-    [raspbian]='\xef\x8c\x95'       [raspbian_color]=125
-    [redhat]='\xee\x9e\xbb'         [redhat_color]=1
-    [rhel]='\xee\x9e\xbb'           [rhel_color]=1
-    [sabayon]='\xef\x8c\x97'        [sabayon_color]=255
-    [slackware]='\xef\x8c\x98'      [slackware_color]=63
-    [sles]='\xef\x8c\x94'           [sles_color]=113
-    [ubuntu]='\xef\x8c\x9b'         [ubuntu_color]=166
-    [windows]='\xee\x98\xaa'        [windows_color]=6
+    [amzn]='\xef\x94\xac'                [amzn_color]=208
+    [android]='\xef\x85\xbb'             [android_color]=113
+    [arch]='\xef\x8c\x83'                [arch_color]=25
+    [archarm]='\xef\x8c\x83'             [archarm_color]=125
+    [alpine]='\xef\x8c\x80'              [alpine_color]=24
+    [aosc]='\xef\x8c\x81'                [aosc_color]=172
+    [centos]='\xef\x8c\x84'              [centos_color]=27
+    [cloud]='\xef\x99\x9e'               [cloud_color]=39
+    [coreos]='\xef\x8c\x85'              [coreos_color]=32
+    [darwin]='\xef\x94\xb4'              [darwin_color]=15
+    [debian]='\xee\x9d\xbd'              [debian_color]=88
+    [devuan]='\xef\x8c\x87'              [devuan_color]=16
+    [docker]='\xee\x9e\xb0'              [docker_color]=26
+    [elementary]='\xef\x8c\x89'          [elementary_color]=33
+    [fedora]='\xef\x8c\x8a'              [fedora_color]=32
+    [freebsd]='\xef\x8c\x8c'             [freebsd_color]=1
+    [gentoo]='\xef\x8c\x8d'              [gentoo_color]=62
+    [linux]='\xef\x85\xbc'               [linux_color]=15
+    [linuxmint]='\xef\x8c\x8e'           [linuxmint_color]=47
+    [mageia]='\xef\x8c\x90'              [mageia_color]=24
+    [mandriva]='\xef\x8c\x91'            [mandriva_color]=208
+    [manjaro]='\xef\x8c\x92'             [manjaro_color]=34
+    [mysql]='\xee\x9c\x84'               [mysql_color]=30
+    [nixos]='\xef\x8c\x93'               [nixos_color]=88
+    [opensuse]='\xef\x8c\x94'            [opensuse_color]=113
+    [opensuse-leap]='\xef\x8c\x94'       [opensuse-leap_color]=113
+    [opensuse-tumbleweed]='\xef\x8c\x94' [opensuse-tumbleweed_color]=113
+    [raspbian]='\xef\x8c\x95'            [raspbian_color]=125
+    [redhat]='\xee\x9e\xbb'              [redhat_color]=1
+    [rhel]='\xee\x9e\xbb'                [rhel_color]=1
+    [sabayon]='\xef\x8c\x97'             [sabayon_color]=255
+    [slackware]='\xef\x8c\x98'           [slackware_color]=63
+    [sles]='\xef\x8c\x94'                [sles_color]=113
+    [ubuntu]='\xef\x8c\x9b'              [ubuntu_color]=166
+    [windows]='\xee\x98\xaa'             [windows_color]=6
 )
 
 function GbtCarOs() {
@@ -49,10 +51,6 @@ function GbtCarOs() {
             os='darwin'
         elif [ "$os" = 'Linux' ] && [ -e /etc/os-release ]; then
             os=$(source /etc/os-release; echo "$ID")
-
-            case $os in opensuse-*)
-                os="opensuse"
-            esac
 
             if [ ! ${GBT__OS_SYMBOLS[$os]+1} ]; then
                 os='linux'


### PR DESCRIPTION
openSUSE Leap 15 and openSUSE Tumbleweed has changed their `ID` in `/etc/os-release`
This makes sure that the chameleon is used in the os car for openSUSE leap 42.3 and earlier as well as Leap 15 and Tumbleweed.

I also added the chameleon for SLES.

I tried to keep the `GbtCarOs()` as portable as possible and stay away from bash extensions and be as POSIX sh as possible. (that's why the use of case/esac)

fixes #30