### PR TITLE
Remove GBT__LOCAL only when su is used

### DIFF
--- a/sources/gbts/cmd/local/sudo.sh
+++ b/sources/gbts/cmd/local/sudo.sh
@@ -4,19 +4,22 @@ function gbt_sudo() {
     local SUDO_BIN=$(gbt__which sudo)
     [ -z "$SUDO_BIN" ] && return 1
 
+    local rv
     if [ "$1" != 'su' ] && [[ " $@ " != *" -i "* ]]; then
         $SUDO_BIN "$@"
+
+        rv=$?
     else
         shift
 
         local GBT__CONF=$(gbt__local_rcfile)
 
         $SUDO_BIN $SU_BIN -s "$GBT__CONF.bash" "$@"
+
+        rv=$?
+        
+        rm -f $GBT__CONF $GBT__CONF.bash
     fi
-
-    local rv=$?
-
-    rm -f $GBT__CONF $GBT__CONF.bash
 
     return $rv
 }

--- a/sources/gbts/cmd/local/sudo.sh
+++ b/sources/gbts/cmd/local/sudo.sh
@@ -5,10 +5,9 @@ function gbt_sudo() {
     [ -z "$SUDO_BIN" ] && return 1
 
     local rv
+
     if [ "$1" != 'su' ] && [[ " $@ " != *" -i "* ]]; then
         $SUDO_BIN "$@"
-
-        rv=$?
     else
         shift
 
@@ -17,9 +16,9 @@ function gbt_sudo() {
         $SUDO_BIN $SU_BIN -s "$GBT__CONF.bash" "$@"
 
         rv=$?
-        
+
         rm -f $GBT__CONF $GBT__CONF.bash
     fi
 
-    return $rv
+    return ${rv:-$?}
 }


### PR DESCRIPTION
FIxes #32, preserving the return values of the respective `sudo` and `su` commands in the process.