### PR TITLE
Stop forwarding of unwanted aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -2195,40 +2195,33 @@ You can start using it by doing the following:
 
 ```shell
 export GBT__HOME='/usr/share/gbt'
-source "$GBT__HOME/sources/gbts/cmd/local.sh"
-alias docker='gbt_docker'
-alias mysql='gbt_mysql'
-alias screen='gbt_screen'
-alias ssh='gbt_ssh'
-alias su='gbt_su'
-alias sudo='gbt_sudo'
-alias vagrant='gbt_vagrant'
+source $GBT__HOME/sources/gbts/cmd/local.sh
 ```
 
-If you want to have the alias available only on the remote machine, prepend the
-alias by `gbt___`. For example to have the `sudo` alias, using the `gbt_sudo`
-function, available only on the remote machine, define the alias like this:
+This will automatically create command line aliases for all enabled plugins (by
+default `docker`, `mysql`, `screen`, `ssh`, `su`, `sudo` and `vagrant`). Then
+just SSH to some remote server or enter some Docker container or Vagrant box
+and you should get GBT prompt there.
+
+If you want to have some of the default aliase available only on the remote
+site, just un-alias them locally:
 
 ```shell
-alias gbt__sudo='gbt_sudo'
+unalias sudo su
 ```
 
-The same principle applies to any alias you want to have available on the
-remote machine. For example to have `alias ll='ls -l'` on any remote machine,
-just create the following alias and it will be automatically forwarded:
+You can also forward your own aliases which will be then available on any remote
+site. For example to have `alias ll='ls -l'` on any remote site, just create the
+following alias and it will be automatically forwarded:
 
 ```shell
-alias gbt__ll='ls -l'
+alias gbt___ll='ls -l'
 ```
 
-After the prompt forwarding is configured, just SSH to some remote server or
-enter some Docker container or Vagrant box and you should get GBT-like looking
-prompt.
-
-The idea of prompt forwarding is coming from Vladimir Babichev (@mrdrup) who was
-using it for several years before GBT even existed. After seeing the potential of
-GBT, he sparked the implementation of prompt forwarding into GBT which later
-turned into GBTS.
+The idea behind prompt forwarding is coming from Vladimir Babichev
+(@[mrdrup](https://github.com/mrdrup)) who was using it for several years
+before GBT even existed. After seeing the potential of GBT, he sparked the
+implementation of prompt forwarding into GBT which later turned into GBTS.
 
 
 ### Principle
@@ -2259,10 +2252,8 @@ The same or very similar principle applies to other supported commands like
 
 ### Additional settings
 
-GBTS has few settings which can be used to influence which functionality to pass
-on the remote site how the much the sources compress should be compressed. See
-the details
-[here](https://github.com/jtyr/gbt/tree/master/sources/gbts/README.md).
+GBTS has few settings which can be used to influence its behaviour. See the
+details [here](https://github.com/jtyr/gbt/tree/master/sources/gbts/README.md).
 
 
 ### MacOS users

--- a/sources/gbts/README.md
+++ b/sources/gbts/README.md
@@ -52,6 +52,15 @@ export GBT__PLUGINS_REMOTE='docker,mysql,screen,ssh,su,sudo,vagrant'
 # List of plugins to pack for local commands
 export GBT__PLUGINS_LOCAL='docker,mysql,screen,ssh,su,sudo,vagrant'
 
+# Change default name of the alias for SSH (similarly of other plugins)
+export GBT__SSH_ALIAS='sssh'
+
+# Unalias some of the remotely created aliases
+export GBT__UNALIAS_REMOTE='sudo su'
+
+# Disable automatic aliases
+export GBT__AUTO_ALIASES='0'
+
 # Suppress code minimizing
 export GBT__SOURCE_MINIMIZE='cat'
 
@@ -71,7 +80,6 @@ export GBT__SOURCE_MD5_CUT_REMOTE=4
 # When logging from MacOS to Linux (needded for the verification of the GBT script content)
 export GBT__SOURCE_MD5_LOCAL=md5
 export GBT__SOURCE_MD5_CUT_LOCAL=4
-source $GBT__HOME/sources/gbts/cmd/local.sh
 ```
 
 
@@ -88,4 +96,16 @@ Use the following command to convert Unicode character to code:
 
 ```shell
 printf '\\u%02x\n' "'"
+```
+
+Use the following command to convert Unicode code to byte sequence:
+
+```shell
+echo -ne "\ue0b0" | xxd -plain | sed 's/\(..\)/\\x\1/g'
+```
+
+Use the following command to convert byte sequence to Unicode code:
+
+```shell
+printf '\\u%02x\n' "'"$'\xee\x82\xb0'
 ```

--- a/sources/gbts/cmd/local/_common.sh
+++ b/sources/gbts/cmd/local/_common.sh
@@ -99,7 +99,7 @@ function gbt__get_sources() {
         fi
 
         [[ ${GBT__CARS_REMOTE__HASH[@]} == *' ssh '* ]] && [ -n "$GBT__THEME_SSH_CARS" ] && echo "export GBT__THEME_SSH_CARS='$GBT__THEME_SSH_CARS'"
-        alias | awk '/gbt_/ {sub(/^(alias )?(gbt___)?/, "", $0); print "alias "$0}'
+        alias | awk '/gbt___/ {sub(/^(alias )?(gbt___)?/, "", $0); print "alias "$0}'
         echo "PS1='\$(GbtMain \$?)'"
     ) | eval "$GBT__SOURCE_MINIMIZE"
 }

--- a/sources/gbts/cmd/local/_common.sh
+++ b/sources/gbts/cmd/local/_common.sh
@@ -4,6 +4,15 @@ GBT__CARS_REMOTE__HASH=". $(echo ${GBT__CARS_REMOTE:-dir,git,hostname,os,sign,st
 
 GBT__SOURCE_BASE64_LOCAL=${GBT__SOURCE_BASE64_LOCAL:-base64}
 
+declare -A GBT__ALIASES
+GBT__ALIASES[docker]=${GBT__DOCKER_ALIAS:-docker}
+GBT__ALIASES[mysql]=${GBT__MYSQL_ALIAS:-mysql}
+GBT__ALIASES[screen]=${GBT__SCREEN_ALIAS:-screen}
+GBT__ALIASES[ssh]=${GBT__SSH_ALIAS:-ssh}
+GBT__ALIASES[su]=${GBT__SU_ALIAS:-su}
+GBT__ALIASES[sudo]=${GBT__SUDO_ALIAS:-sudo}
+GBT__ALIASES[vagrant]=${GBT__VAGRANT_ALIAS:-vagrant}
+
 
 function gbt__local_rcfile() {
     local GBT__CONF="/tmp/.gbt.$RANDOM"
@@ -49,6 +58,19 @@ function gbt__get_sources() {
         echo "export GBT__CONF='$GBT__CONF'"
         echo "export GBT__CONF_SBIN_PATH='$GBT__CONF_SBIN_PATH'"
         cat $GBT__HOME/sources/gbts/{cmd{,/remote},car}/_common.sh
+
+        # Automatic aliases
+        if [[ ${GBT__AUTO_ALIASES:-1} == 1 ]]; then
+            for plugin in $(echo $GBT__PLUGINS_REMOTE__HASH | sed 's/\ /\n/g'); do
+                if [[ $plugin != '.' ]]; then
+                    echo "alias ${GBT__ALIASES[$plugin]}='gbt_$plugin'"
+                fi
+            done
+
+            if [[ -n $GBT__UNALIAS_REMOTE ]]; then
+                echo "unalias $GBT__UNALIAS_REMOTE 2>/dev/null"
+            fi
+        fi
 
         # Include SSH common function if car is present
         if [[ ${GBT__PLUGINS_REMOTE__HASH[@]} == *' ssh '* ]]; then

--- a/sources/gbts/cmd/local/docker.sh
+++ b/sources/gbts/cmd/local/docker.sh
@@ -16,3 +16,5 @@ function gbt_docker() {
         unset GBT__CONF
     fi
 }
+
+[[ ${GBT__AUTO_ALIASES:-1} == 1 ]] && alias "${GBT__ALIASES[docker]}"='gbt_docker'

--- a/sources/gbts/cmd/local/mysql.sh
+++ b/sources/gbts/cmd/local/mysql.sh
@@ -6,3 +6,5 @@ function gbt_mysql() {
 
     $MYSQL_BIN --prompt "$(source $GBT__THEME_MYSQL; $GBT__HOME/sources/gbts/gbts)" "$@"
 }
+
+[[ ${GBT__AUTO_ALIASES:-1} == 1 ]] && alias "${GBT__ALIASES[mysql]}"='gbt_mysql'

--- a/sources/gbts/cmd/local/screen.sh
+++ b/sources/gbts/cmd/local/screen.sh
@@ -8,3 +8,5 @@ function gbt_screen() {
 
     rm -f $GBT__CONF $GBT__CONF.bash
 }
+
+[[ ${GBT__AUTO_ALIASES:-1} == 1 ]] && alias "${GBT__ALIASES[screen]}"='gbt_screen'

--- a/sources/gbts/cmd/local/ssh.sh
+++ b/sources/gbts/cmd/local/ssh.sh
@@ -22,3 +22,5 @@ chmod $GBT__CONF_MODE \$GBT__CONF;
 exec -a gbt.bash bash --rcfile \$GBT__CONF"
     fi
 }
+
+[[ ${GBT__AUTO_ALIASES:-1} == 1 ]] && alias "${GBT__ALIASES[ssh]}"='gbt_ssh'

--- a/sources/gbts/cmd/local/su.sh
+++ b/sources/gbts/cmd/local/su.sh
@@ -8,3 +8,5 @@ function gbt_su() {
 
     rm -f $GBT__CONF $GBT__CONF.bash
 }
+
+[[ ${GBT__AUTO_ALIASES:-1} == 1 ]] && alias "${GBT__ALIASES[su]}"='gbt_su'

--- a/sources/gbts/cmd/local/sudo.sh
+++ b/sources/gbts/cmd/local/sudo.sh
@@ -22,3 +22,5 @@ function gbt_sudo() {
 
     return ${rv:-$?}
 }
+
+[[ ${GBT__AUTO_ALIASES:-1} == 1 ]] && alias "${GBT__ALIASES[sudo]}"='gbt_sudo'

--- a/sources/gbts/cmd/local/vagrant.sh
+++ b/sources/gbts/cmd/local/vagrant.sh
@@ -23,3 +23,5 @@ exec -a gbt.bash bash --rcfile \$GBT__CONF" "$@"
         $VAGRANT_BIN "$@"
     fi
 }
+
+[[ ${GBT__AUTO_ALIASES:-1} == 1 ]] && alias "${GBT__ALIASES[vagrant]}"='gbt_vagrant'


### PR DESCRIPTION
Forward only aliases prefixed with `gbt___`.

Example of unexpected behaviour:
```
00:33:58 ✔ [mac] ~  alias | grep gbt_
alias docker='gbt_docker'
alias gbt___dp='docker ps --format "table {{.ID}}\t{{.Image}}\t{{.Names}}\t{{.Status}}\t{{.Ports}}"'
00:34:02 ✔ [mac] ~  echo $GBT__PLUGINS_REMOTE
ssh,sudo
00:34:11 ✔ [mac] ~  gbt_ssh vagrant@127.0.0.1 -p 2200
  00:34:18 ✔ [vagrant@test] ~ # alias | grep gbt
alias docker='gbt_docker'
  00:34:26 ✔ [vagrant@test] ~ #
```
