### PR TITLE
Use 'go get' instead of 'go install'

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Make sure Go is installed and then run:
 mkdir ~/go
 export GOPATH=~/go
 export PATH="$PATH:$GOPATH/bin"
-go install github.com/jtyr/gbt/cmd/gbt
+go get github.com/jtyr/gbt/cmd/gbt
 ```
 
 ---


### PR DESCRIPTION
`go get` is needed for users that don't clone the repository. OTOH `go install` needs an already downloaded source code.