### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,12 @@ distribution regardless its version.
 
 Packages hosted by [Packagecloud](https://packagecloud.io/gbt/release):
 
+Ubuntu 22.04
+
 ```shell
+# When you get message "Warning: apt-key is deprecated. Manage keyring files in trusted.gpg.d instead (see apt-key(8))."
+# use command:
+# curl -L https://packagecloud.io/gbt/release/gpgkey | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/gbt.gpg >/dev/null
 curl -L https://packagecloud.io/gbt/release/gpgkey | sudo apt-key add -
 echo 'deb https://packagecloud.io/gbt/release/ubuntu/ xenial main' | sudo tee /etc/apt/sources.list.d/gbt.list >/dev/null
 sudo apt-get update


### PR DESCRIPTION
Fix apt-key deprecation warning on latest ubuntu 22.04.