### PR TITLE
Update README.md for installation using code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Or the following on Windows using PowerShell:
 mkdir ~/go
 $Env:GOPATH = '~/go'
 $Env:PATH = "~/go/bin;$Env:PATH"
-go get github.com/jtyr/gbt/cmd/gbt
+go install github.com/jtyr/gbt/cmd/gbt@latest
 ```
 
 ---


### PR DESCRIPTION
Go doesn't support `go get` out side of a package.